### PR TITLE
Use nativetls feature to work around issues with OpenSSL on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = "0.1.50"
 oneshot = "0.1.2"
 log = "0.4.14"
 isahc = "1.4.0"
-qws = { version = "0.7.9", features = ["ssl"] }
+qws = { version = "0.7.9", features = ["nativetls"] }
 
 [dev-dependencies]
 simple_logger = "1.11.0"


### PR DESCRIPTION
Using the old nakama-rs, packaging my game as an MSIX caused issues with OpenSSL availability. Given the challenges of OpenSSL on Windows, using this feature seems like the best path forward since it claims to use whatever is appropriate for the platform.